### PR TITLE
Support secret parameters feature

### DIFF
--- a/lib/fluent/plugin/out_http.rb
+++ b/lib/fluent/plugin/out_http.rb
@@ -27,7 +27,7 @@ class Fluent::HTTPOutput < Fluent::Output
   # nil | 'none' | 'basic'
   config_param :authentication, :string, :default => nil 
   config_param :username, :string, :default => ''
-  config_param :password, :string, :default => ''
+  config_param :password, :string, :default => '', :secret => true
 
   def configure(conf)
     super


### PR DESCRIPTION
Fluentd v0.12 supports secret parameters feature.
This feature works as bellow with Fluentd v0.12.x:

```log
  <match *>
    type http
    endpoint_url http://localhost.local/api/
    http_method put
    serializer json
    rate_limit_msec 100
    raise_on_error false
    authentication basic
    username alice
    password xxxxxx
  </match>
</ROOT>
```

If you use older fluentd, `:secret => true` in config_param wille be simply ignored.