### PR TITLE
Loosen Fluentd dependency in gemspec

### DIFF
--- a/fluent-plugin-out-http.gemspec
+++ b/fluent-plugin-out-http.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_runtime_dependency "yajl-ruby", "~> 1.0"
-  gem.add_runtime_dependency "fluentd", "~> 0.10.0"
+  gem.add_runtime_dependency "fluentd", [">= 0.10.0", "< 2"]
   gem.add_development_dependency "bundler"
   gem.add_development_dependency "rake"
 end


### PR DESCRIPTION
Now, `[">= 0.10.0", "< 2"]` is prefer to `"~> 0.10.0"` for Fluentd dependency.