### PR TITLE
Add support for custom formatters

### DIFF
--- a/lib/fluent/plugin/out_http.rb
+++ b/lib/fluent/plugin/out_http.rb
@@ -66,6 +66,7 @@ class Fluent::HTTPOutput < Fluent::Output
 
     @last_request_time = nil
 
+    @formatter = nil
     unless @format.empty?
       @formatter = Fluent::Plugin.new_formatter(@format)
       @formatter.configure(conf)

--- a/lib/fluent/plugin/out_http.rb
+++ b/lib/fluent/plugin/out_http.rb
@@ -32,6 +32,9 @@ class Fluent::HTTPOutput < Fluent::Output
   config_param :username, :string, :default => ''
   config_param :password, :string, :default => '', :secret => true
 
+  # Formatter support so you can format your request body before sending
+  config_param :format, :string, :default => ''
+
   def configure(conf)
     super
 
@@ -62,6 +65,11 @@ class Fluent::HTTPOutput < Fluent::Output
             end
 
     @last_request_time = nil
+
+    unless @format.empty?
+      @formatter = Fluent::Plugin.new_formatter(@format)
+      @formatter.configure(conf)
+    end
   end
 
   def start
@@ -143,6 +151,9 @@ class Fluent::HTTPOutput < Fluent::Output
   end # end send_request
 
   def handle_record(tag, time, record)
+    if @formatter
+      record = @formatter.format(tag, time, record)
+    end
     req, uri = create_request(tag, time, record)
     send_request(req, uri)
   end

--- a/lib/fluent/test/formatter_test.rb
+++ b/lib/fluent/test/formatter_test.rb
@@ -11,8 +11,8 @@ module Fluent
 
       def format(tag, time, record)
         output = {
-          "wrapped": true,
-          "record": record
+          "wrapped" => true,
+          "record" => record
         }
         output
       end

--- a/lib/fluent/test/formatter_test.rb
+++ b/lib/fluent/test/formatter_test.rb
@@ -1,0 +1,21 @@
+require 'fluent/formatter'
+
+module Fluent
+  module TextFormatter
+    class TestFormatter < Formatter
+      Plugin.register_formatter('test_formatter', self)
+
+      def configure(conf)
+        super
+      end
+
+      def format(tag, time, record)
+        output = {
+          "wrapped": true,
+          "record": record
+        }
+        output
+      end
+    end
+  end
+end

--- a/test/plugin/test_out_http.rb
+++ b/test/plugin/test_out_http.rb
@@ -383,3 +383,23 @@ class HTTPSOutputTest < HTTPOutputTestBase
     assert_equal '50', record[:form]['field1']
   end
 end
+
+
+class CustomFormatterTest < HTTPOutputTestBase
+  FORMATTER_CONF = %[
+    endpoint_url http://127.0.0.1:#{port}/api/
+    serializer json
+    format test_formatter
+  ]
+
+  def test_custom_formatter
+    d = create_driver FORMATTER_CONF
+    payload = {"field" => 1}
+    d.emit(payload)
+    d.run
+
+    record = @posts[0]
+    assert_equal record[:json]["wrapped"], true
+    assert_equal record[:json]["record"], payload
+  end
+end


### PR DESCRIPTION
The purpose of custom formatters is if you need to change or modify the request body format, which enables more flexibility in integrating to other sources.